### PR TITLE
Makefile improvements

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: lgutter <lgutter@student.codam.nl>           +#+                      #
 #                                                    +#+                       #
 #    Created: 2019/01/16 14:00:27 by lgutter        #+#    #+#                 #
-#    Updated: 2019/10/12 11:51:24 by lgutter       ########   odam.nl          #
+#    Updated: 2019/11/04 16:22:28 by lgutter       ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,7 +14,11 @@ NAME := libft.a
 include ./Sources
 include ./CovSources
 
-FLGS := -Wall -Wextra -Werror -c -g
+CC := gcc
+CFLAGS := -Wall -Wextra -Werror -g -coverage
+
+JUNK := *.gcov *.gcno *.gcda *~ \#*# *.zip
+
 SRCS := $(LFTSOURCES:%= %.c)
 OBJS := $(LFTSOURCES:%= %.o)
 COVSRCS := $(COVSOURCES:%= %.c)
@@ -25,30 +29,27 @@ C_CLEAN = \033[38;5;159m
 C_FCLEAN = \033[38;5;81m
 C_OBJECTS = \033[38;5;75m
 C_LIB = \033[38;5;33m
+C_LINES = \033[38;5;250m
 
 all: $(NAME)
 
-$(NAME):
-	@make objects
-	@ar rc $(NAME) $(OBJS) $(COVOBJS)
+$(NAME): $(COVOBJS) $(OBJS)
+	@ar rc $@ $^
 	@ranlib $(NAME)
 	@echo "$(C_LIB)Libft.a has been compiled$(C_RESET)"
 
-objects: $(COVOBJS) $(OBJS)
-
-$(COVOBJS):
-	@gcc $(FLGS) -coverage $(COVSRCS)
-
-$(OBJS):
-	@gcc $(FLGS) $(SRCS)
-	@echo "$(C_OBJECTS)Libft object files compiled$(C_RESET)"
+%.o: %.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c $^ -o $@
 
 clean:
-	@rm -rf $(OBJS) $(COVOBJS) *.gcov *.gcno *.gcda *~ \#*# *.zip
+	@rm -rf $(OBJS) $(COVOBJS) $(JUNK)
 	@echo "$(C_CLEAN)Libft object files removed$(C_RESET)"
 
 fclean: clean
 	@rm -rf $(NAME)
 	@echo "$(C_FCLEAN)Libft.a removed$(C_RESET)"
+	@echo "$(C_LINES)- - - - - - - - - -$(C_RESET)"
 
 re: fclean all
+
+.PHONY: all objects clean fclean re


### PR DESCRIPTION
The ft_printf makefile no longer needs the libft makefile.
It uses one rule to compile any object file,
and everything has proper dependency tracking.
Also removed retest rule since we shouldn't use it,
and added PHONY specifications.
closes #38 