### PR TITLE
fixed precision in d/i

### DIFF
--- a/ft_find_precision.c
+++ b/ft_find_precision.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/01 15:31:26 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/19 11:52:08 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/19 15:26:22 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,27 +14,27 @@
 
 int		ft_find_precision(const char *format, t_info *info, int i)
 {
-	size_t nb;
+	int	asterisk;
 
-	nb = 0;
+	asterisk = 0;
 	if (format[i] == '.')
 	{
 		info->precfound = 1;
 		i++;
-		nb = ft_atoi(&format[i]);
-		info->precision = nb;
+		if (format[i] == '*')
+		{
+			asterisk = va_arg(info->arguments, int);
+			info->precision = asterisk >= 0 ? asterisk : 1;
+			i++;
+		}
+		else
+			info->precision = ft_atoi(&format[i]);
 		if (info->flags & e_zero)
-		{
 			info->flags -= e_zero;
-		}
 		if (ft_isdigit(format[i]) == 1)
-		{
-			i += ft_nbrlenbase(nb, 10);
-		}
+			i += ft_nbrlenbase(info->precision, 10);
 	}
 	else
-	{
 		info->precfound = -1;
-	}
 	return (i);
 }

--- a/ft_formatlonglong.c
+++ b/ft_formatlonglong.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/13 14:35:42 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/18 19:33:20 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/19 12:47:15 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,18 +26,15 @@ static int	ft_format_neglonglong(long long n, t_info *info)
 	else
 		info->len = 0;
 	nb = ft_itoa_base(n, 10);
-	nb = ft_precision_int(info, nb);
+	if (info->precfound > 0)
+		nb = ft_precision_int(info, nb);
 	if (nb == NULL)
 		return (-1);
 	info->len += ft_strlen(nb);
 	if ((info->flags & e_minus) != 0)
-	{
 		ft_write_order(info, nb, "rw");
-	}
 	else
-	{
 		ft_write_order(info, nb, "wr");
-	}
 	return (0);
 }
 
@@ -49,7 +46,8 @@ int			ft_formatlonglong(long long n, t_info *info)
 		return (ft_format_neglonglong(n, info));
 	info->sign = 1;
 	nb = ft_itoa_base(n, 10);
-	nb = ft_precision_int(info, nb);
+	if (info->precfound > 0)
+		nb = ft_precision_int(info, nb);
 	if (nb == NULL)
 		return (-1);
 	info->len = ft_strlen(nb);

--- a/tests/int_precision_tests.c
+++ b/tests/int_precision_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/18 15:44:54 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/18 20:24:57 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/19 15:25:19 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -451,7 +451,7 @@ Test(test_printf_precision_int, int_minus_3_width_0_3_precision_l_d, .init = red
 	cr_assert_stdout_eq_str(result);
 }
 
-Test(test_printf_precision_int, int_minus_3_width_MAX_5_precision_h_d, .init = redirect_std_out)
+Test(test_printf_precision_int, int_minus_3_width_MAX_5_precision_l_d, .init = redirect_std_out)
 {
 	long d;
 	char *result = NULL;
@@ -463,7 +463,7 @@ Test(test_printf_precision_int, int_minus_3_width_MAX_5_precision_h_d, .init = r
 	cr_assert_stdout_eq_str(result);
 }
 
-Test(test_printf_precision_int, int_minus_5_width_MAX_32_precision_h_d, .init = redirect_std_out)
+Test(test_printf_precision_int, int_minus_5_width_MAX_32_precision_l_d, .init = redirect_std_out)
 {
 	long d;
 	char *result = NULL;
@@ -472,5 +472,41 @@ Test(test_printf_precision_int, int_minus_5_width_MAX_32_precision_h_d, .init = 
 	fflush(stdout);
 
 	asprintf(&result, "%-5.32ld", d);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_printf_precision_int, int_minus_5_width_MAX_asterisk_precision_l_d, .init = redirect_std_out)
+{
+	long d;
+	char *result = NULL;
+	d = 9223372036854775807;
+	ft_printf("%-5.*ld", 32, d);
+	fflush(stdout);
+
+	asprintf(&result, "%-5.*ld", 32, d);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_printf_precision_int, int_minus_5_width_42_asterisk_precision_l_d, .init = redirect_std_out)
+{
+	long d;
+	char *result = NULL;
+	d = 42;
+	ft_printf("%-5.*ld", -5, d);
+	fflush(stdout);
+
+	asprintf(&result, "%-5.*ld", -5, d);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_printf_precision_int, int_minus_5_width_0_asterisk_precision_l_d, .init = redirect_std_out)
+{
+	long d;
+	char *result = NULL;
+	d = 0;
+	ft_printf("%-5.*ld", 0, d);
+	fflush(stdout);
+
+	asprintf(&result, "%-5.*ld", 0, d);
 	cr_assert_stdout_eq_str(result);
 }


### PR DESCRIPTION
precision was always handled, even if no precision was found.
fixed that with an extra specifier in the info struct.

_we need to integrate this into `x` `X` and `o` as well!_