### PR TITLE
fixed wildcards and empty specifier

### DIFF
--- a/ft_find_precision.c
+++ b/ft_find_precision.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/01 15:31:26 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/27 11:19:51 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/27 18:14:32 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,8 @@ int		ft_find_precision(const char *format, t_info *info, int i)
 		if (format[i] == '*')
 		{
 			asterisk = va_arg(info->arguments, int);
-			info->precision = asterisk >= 0 ? asterisk : 1;
+			info->precision = asterisk;
+			info->precfound = asterisk >= 0 ? 1 : -1;
 			i++;
 		}
 		else

--- a/ft_find_width.c
+++ b/ft_find_width.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/01 13:57:09 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/16 18:41:14 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/27 18:07:54 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,11 @@ int			ft_find_width(const char *format, t_info *info, int i)
 	if (format[i] == '*')
 	{
 		nb = va_arg(info->arguments, int);
+		if (nb < 0)
+		{
+			info->flags |= e_minus;
+			nb *= -1;
+		}
 		i++;
 	}
 	else

--- a/ft_formatunknown.c
+++ b/ft_formatunknown.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/10/27 17:35:37 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/27 13:56:14 by ivan-tey      ########   odam.nl         */
+/*   Updated: 2019/11/27 17:55:55 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,8 @@
 int		ft_formatunknown(t_info *info, char c)
 {
 	info->len = 1;
+	if (c == '\0')
+		return (0);
 	if ((info->flags & e_minus) != 0)
 	{
 		info->writer(info->target, &info->totallen, &c, 1);

--- a/tests/check_width_tests.c
+++ b/tests/check_width_tests.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/07 11:32:15 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/16 18:43:07 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/27 18:08:46 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,5 +141,29 @@ Test(test_width, double_minus_twelve_int, .init = redirect_stdout)
 	fflush(stdout);
 
 	asprintf(&result, "%--12i", d);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_width, asterisk_negative_width_int, .init = redirect_stdout)
+{
+	int d;
+	char *result = NULL;
+	d = 42;
+	ft_printf("%*i", -5, d);
+	fflush(stdout);
+
+	asprintf(&result, "%*i", -5, d);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_width, minus_asterisk_negative_width_int, .init = redirect_stdout)
+{
+	int d;
+	char *result = NULL;
+	d = 42;
+	ft_printf("%-*i", -5, d);
+	fflush(stdout);
+
+	asprintf(&result, "%-*i", -5, d);
 	cr_assert_stdout_eq_str(result);
 }

--- a/tests/format_str_tests.c
+++ b/tests/format_str_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/19 12:51:45 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/25 16:24:52 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/11/27 18:12:02 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -417,5 +417,15 @@ Test(test_format_str_precision, test_string_zero_prefix_precision_small_width_NU
 	fflush(stdout);
 
 	asprintf(&result, "%3.03s", str);
+	cr_assert_stdout_eq_str(result);
+}
+
+Test(test_format_str_precision, test_string_zero_prefix_precision_asterisk_negative, .init = redirect_std_out) {
+	char *str = "42";
+	char *result = NULL;
+	ft_printf("%3.*s", -5, str);
+	fflush(stdout);
+
+	asprintf(&result, "%3.*s", -5, str);
 	cr_assert_stdout_eq_str(result);
 }


### PR DESCRIPTION
if the wildcard argument is negative, it is now correctly handled.
If the format string ends with a %, it will no longer try to print the null delimiter.