### PR TITLE
Feature/middlewidth

### DIFF
--- a/Source_files/Find_files/ft_find_flags.c
+++ b/Source_files/Find_files/ft_find_flags.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/01 12:25:51 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/12/04 15:52:47 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:44:25 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,8 @@ int		ft_find_flags(const char *format, t_info *info, int i)
 			return (i);
 		if ((info->flags & e_space) != 0 && (info->flags & e_plus) != 0)
 			info->flags -= e_space;
-		if ((info->flags & e_zero) != 0 && (info->flags & e_minus) != 0)
+		if ((info->flags & e_zero) != 0 && ((info->flags & e_minus) != 0 ||
+			(info->flags & e_middle) != 0))
 			info->flags -= e_zero;
 		i++;
 	}

--- a/Source_files/Find_files/ft_find_flags.c
+++ b/Source_files/Find_files/ft_find_flags.c
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/01 12:25:51 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/15 21:57:32 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 15:52:47 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ int		ft_find_flags(const char *format, t_info *info, int i)
 			info->flags |= e_zero;
 		else if (format[i] == '#')
 			info->flags |= e_hash;
+		else if (format[i] == '^')
+			info->flags |= e_middle;
 		else
 			return (i);
 		if ((info->flags & e_space) != 0 && (info->flags & e_plus) != 0)

--- a/Source_files/Format_files/csp_files/ft_formatstring.c
+++ b/Source_files/Format_files/csp_files/ft_formatstring.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/10/14 16:45:31 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/29 12:59:23 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:05:55 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,16 +19,19 @@ int		ft_formatstring(t_info *info)
 	str = NULL;
 	info->conv = 's';
 	str = va_arg(info->arguments, char *);
+	if (str != NULL)
+		str = ft_strdup(str);
 	if (str == NULL)
-		str = "(null)";
+		str = ft_strdup("(null)");
 	info->len = ft_precision_string(info, &str);
+	str[info->len] = '\0';
 	if ((info->flags & e_minus) != 0)
 	{
-		info->writer(info->target, &info->totallen, str, info->len);
-		ft_write_width(info, info->len);
+		ft_write_order(info, str, "rw");
+		free(str);
 		return (0);
 	}
-	ft_write_width(info, info->len);
-	info->writer(info->target, &info->totallen, str, info->len);
+	ft_write_order(info, str, "wr");
+	free(str);
 	return (0);
 }

--- a/Source_files/Format_files/csp_files/ft_precision_string.c
+++ b/Source_files/Format_files/csp_files/ft_precision_string.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/19 16:02:07 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/25 16:01:59 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:07:29 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ size_t	ft_precision_string(t_info *info, char **string)
 	}
 	else if (info->precision < 1)
 	{
-		*string = "";
+		*string = ft_strdup("");
 		return (0);
 	}
 	else if (ft_strlen(*string) > info->precision)

--- a/Source_files/Write_files/ft_write_middle_width.c
+++ b/Source_files/Write_files/ft_write_middle_width.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/12/04 14:24:14 by lgutter        #+#    #+#                */
-/*   Updated: 2019/12/04 16:34:23 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:43:07 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,10 +16,7 @@ static void		print_padding(t_info *info, size_t len)
 {
 	while (len > 0)
 	{
-		if ((info->flags & e_zero) != 0)
-			info->writer(info->target, &info->totallen, "0", 1);
-		else
-			info->writer(info->target, &info->totallen, " ", 1);
+		info->writer(info->target, &info->totallen, " ", 1);
 		len--;
 	}
 }

--- a/Source_files/Write_files/ft_write_middle_width.c
+++ b/Source_files/Write_files/ft_write_middle_width.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/12/04 14:24:14 by lgutter        #+#    #+#                */
-/*   Updated: 2019/12/04 16:16:12 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:34:23 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,7 @@ static void		write_middle_order(t_info *info, size_t len, char *str, char *o)
 		}
 		else if (*o == 'r')
 		{
+			ft_write_flags(info);
 			info->writer(info->target, &info->totallen, str, 0);
 		}
 		o++;

--- a/Source_files/Write_files/ft_write_middle_width.c
+++ b/Source_files/Write_files/ft_write_middle_width.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_write_middle_width.c                            :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2019/12/04 14:24:14 by lgutter        #+#    #+#                */
+/*   Updated: 2019/12/04 16:16:12 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+static void		print_padding(t_info *info, size_t len)
+{
+	while (len > 0)
+	{
+		if ((info->flags & e_zero) != 0)
+			info->writer(info->target, &info->totallen, "0", 1);
+		else
+			info->writer(info->target, &info->totallen, " ", 1);
+		len--;
+	}
+}
+
+static void		write_middle_order(t_info *info, size_t len, char *str, char *o)
+{
+	while (*o != '\0')
+	{
+		if (*o == 's')
+		{
+			print_padding(info, len / 2);
+		}
+		else if (*o == 'l')
+		{
+			print_padding(info, len - (len / 2));
+		}
+		else if (*o == 'r')
+		{
+			info->writer(info->target, &info->totallen, str, 0);
+		}
+		o++;
+	}
+}
+
+void			ft_write_middle_width(t_info *info, char *str)
+{
+	size_t		len;
+
+	len = 0;
+	if (info->width > 0 && info->width > info->len)
+	{
+		len = info->width - info->len;
+		if (len % 2 == 0)
+		{
+			write_middle_order(info, len, str, "srs");
+		}
+		else
+		{
+			if ((info->flags & e_minus) != 0)
+			{
+				write_middle_order(info, len, str, "srl");
+			}
+			else
+			{
+				write_middle_order(info, len, str, "lrs");
+			}
+		}
+	}
+}

--- a/Source_files/Write_files/ft_write_order.c
+++ b/Source_files/Write_files/ft_write_order.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/16 15:54:51 by lgutter        #+#    #+#                */
-/*   Updated: 2019/11/29 12:59:23 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:03:37 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,13 +31,20 @@ int	ft_write_order(t_info *info, char *str, char *order)
 		{
 			ft_write_flags(info);
 		}
-		else if (*order == 'w')
+		else if (*order == 'w' && (info->flags & e_middle) == 0)
 		{
 			ft_write_width(info, info->len);
 		}
 		else if (*order == 'r')
 		{
-			info->writer(info->target, &info->totallen, str, 0);
+			if ((info->flags & e_middle) != 0)
+			{
+				ft_write_middle_width(info, str);
+			}
+			else
+			{
+				info->writer(info->target, &info->totallen, str, 0);
+			}
 		}
 		order++;
 	}

--- a/Source_files/Write_files/ft_write_order.c
+++ b/Source_files/Write_files/ft_write_order.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/11/16 15:54:51 by lgutter        #+#    #+#                */
-/*   Updated: 2019/12/04 16:03:37 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:34:38 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ int	ft_write_order(t_info *info, char *str, char *order)
 {
 	while (*order != '\0')
 	{
-		if (*order == 'f')
+		if (*order == 'f' && (info->flags & e_middle) == 0)
 		{
 			ft_write_flags(info);
 		}

--- a/Source_files/printfsources
+++ b/Source_files/printfsources
@@ -26,6 +26,7 @@ Write_files/ft_write_flags \
 Write_files/ft_write_order \
 Write_files/ft_write_width \
 Write_files/ft_writer_fd \
+Write_files/ft_write_middle_width\
 ft_dispatcher \
 ft_init_info \
 ft_printf \

--- a/Test_files/middle_width_tests.c
+++ b/Test_files/middle_width_tests.c
@@ -1,0 +1,164 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   middle_width_tests.c                               :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2019/12/04 13:09:09 by lgutter        #+#    #+#                */
+/*   Updated: 2019/12/04 15:45:55 by lgutter       ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "ft_printf.h"
+
+static void redirect_std_out(void)
+{
+	cr_redirect_stdout();
+}
+
+Test(test_middle_width, str_even_width_even_len, .init = redirect_std_out)
+{
+	char *str = "test";
+	ft_printf("%^8s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  test  ");
+}
+
+Test(test_middle_width, str_even_width_uneven_len, .init = redirect_std_out)
+{
+	char *str = "hoi";
+	ft_printf("%^8s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("   hoi  ");
+}
+
+Test(test_middle_width, str_even_width_uneven_len_minus, .init = redirect_std_out)
+{
+	char *str = "hoi";
+	ft_printf("%^-8s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  hoi   ");
+}
+
+Test(test_middle_width, str_uneven_width_even_len, .init = redirect_std_out)
+{
+	char *str = "test";
+	ft_printf("%^9s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("   test  ");
+}
+
+Test(test_middle_width, str_uneven_width_even_len_minus, .init = redirect_std_out)
+{
+	char *str = "test";
+	ft_printf("%^-9s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  test   ");
+}
+
+Test(test_middle_width, str_uneven_width_uneven_len, .init = redirect_std_out)
+{
+	char *str = "hallo";
+	ft_printf("%^9s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  hallo  ");
+}
+
+Test(test_middle_width, str_uneven_width_uneven_len_minus, .init = redirect_std_out)
+{
+	char *str = "hallo";
+	ft_printf("%^-9s", str);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  hallo  ");
+}
+
+Test(test_middle_width, int_even_width_even_len, .init = redirect_std_out)
+{
+	int d = 4242;
+	ft_printf("%^8d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  4242  ");
+}
+
+Test(test_middle_width, int_even_width_uneven_len, .init = redirect_std_out)
+{
+	int d = 42420;
+	ft_printf("%^8d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  42420 ");
+}
+
+Test(test_middle_width, int_even_width_uneven_len_minus, .init = redirect_std_out)
+{
+	int d = 42420;
+	ft_printf("%^-8d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str(" 42420  ");
+}
+
+Test(test_middle_width, int_uneven_width_even_len, .init = redirect_std_out)
+{
+	int d = 4242;
+	ft_printf("%^9d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("   4242  ");
+}
+
+Test(test_middle_width, int_uneven_width_even_len_minus, .init = redirect_std_out)
+{
+	int d = 4242;
+	ft_printf("%^-9d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  4242   ");
+}
+
+Test(test_middle_width, int_uneven_width_uneven_len, .init = redirect_std_out)
+{
+	int d = 42420;
+	ft_printf("%^9d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  42420  ");
+}
+
+Test(test_middle_width, int_uneven_width_uneven_len_minus, .init = redirect_std_out)
+{
+	int d = 42420;
+	ft_printf("%^-9d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  42420  ");
+}
+
+Test(test_middle_width, test_zero_flag, .init = redirect_std_out)
+{
+	int d = 42420;
+	ft_printf("%0^-9d", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str("  42420  ");
+}
+
+Test(test_middle_width, test_precision, .init = redirect_std_out)
+{
+	float f = 4.4242;
+	ft_printf("%0^-9.4f", f);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str(" 4.4242  ");
+}

--- a/Test_files/middle_width_tests.c
+++ b/Test_files/middle_width_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/12/04 13:09:09 by lgutter        #+#    #+#                */
-/*   Updated: 2019/12/04 15:45:55 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:36:14 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -157,8 +157,26 @@ Test(test_middle_width, test_zero_flag, .init = redirect_std_out)
 Test(test_middle_width, test_precision, .init = redirect_std_out)
 {
 	float f = 4.4242;
-	ft_printf("%0^-9.4f", f);
+	ft_printf("%^-9.4f", f);
 	fflush(stdout);
 
 	cr_assert_stdout_eq_str(" 4.4242  ");
+}
+
+Test(test_middle_width, test_hash_hex, .init = redirect_std_out)
+{
+	int d = 4243;
+	ft_printf("%#0^-9.4x", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str(" 0x1093  ");
+}
+
+Test(test_middle_width, test_hash_octal, .init = redirect_std_out)
+{
+	int d = 4243;
+	ft_printf("%#0^-9.4o", d);
+	fflush(stdout);
+
+	cr_assert_stdout_eq_str(" 010223  ");
 }

--- a/Test_files/middle_width_tests.c
+++ b/Test_files/middle_width_tests.c
@@ -6,7 +6,7 @@
 /*   By: lgutter <lgutter@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/12/04 13:09:09 by lgutter        #+#    #+#                */
-/*   Updated: 2019/12/04 16:36:14 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 16:44:40 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -148,7 +148,7 @@ Test(test_middle_width, int_uneven_width_uneven_len_minus, .init = redirect_std_
 Test(test_middle_width, test_zero_flag, .init = redirect_std_out)
 {
 	int d = 42420;
-	ft_printf("%0^-9d", d);
+	ft_printf("%0^9d", d);
 	fflush(stdout);
 
 	cr_assert_stdout_eq_str("  42420  ");

--- a/Test_files/testsources
+++ b/Test_files/testsources
@@ -1,39 +1,40 @@
-TESTSOURCES = basic_std_arg_test \
-byteint_lowhex_tests \
-byteint_octal_tests \
-byteint_tests \
-byteint_upphex_tests \
-check_width_tests \
-find_flags_tests \
-float_tests \
-format_str_tests \
-formatchar_tests \
-int_precision_tests \
-int_tests \
-itoa_base_test \
-long_long_lowhex_tests \
-long_long_octal_tests \
-long_long_tests \
-long_long_upphex_tests \
-long_lowhex_tests \
-long_octal_tests \
-long_tests \
-long_upphex_tests \
-lowhex_precison_tests \
-lowhex_tests \
-octal_precision_tests \
-octal_tests \
-options_test \
-pointer_tests \
-short_lowhex_tests \
-short_octal_tests \
-short_tests \
-short_upphex_tests \
-strexpand_tests \
-ulltoa_base_low_test \
-ulltoa_base_upp_test \
-unsigned_byteint_tests \
-unsigned_int_precision_tests \
-unsigned_int_tests \
-upphex_precision_tests \
-upphex_tests
+TESTSOURCES = basic_std_arg_test\
+byteint_lowhex_tests\
+byteint_octal_tests\
+byteint_tests\
+byteint_upphex_tests\
+check_width_tests\
+find_flags_tests\
+float_tests\
+format_str_tests\
+formatchar_tests\
+int_precision_tests\
+int_tests\
+itoa_base_test\
+long_long_lowhex_tests\
+long_long_octal_tests\
+long_long_tests\
+long_long_upphex_tests\
+long_lowhex_tests\
+long_octal_tests\
+long_tests\
+long_upphex_tests\
+lowhex_precison_tests\
+lowhex_tests\
+octal_precision_tests\
+octal_tests\
+options_test\
+pointer_tests\
+short_lowhex_tests\
+short_octal_tests\
+short_tests\
+short_upphex_tests\
+strexpand_tests\
+ulltoa_base_low_test\
+ulltoa_base_upp_test\
+unsigned_byteint_tests\
+unsigned_int_precision_tests\
+unsigned_int_tests\
+upphex_precision_tests\
+upphex_tests\
+middle_width_tests

--- a/ft_printf.h
+++ b/ft_printf.h
@@ -6,7 +6,7 @@
 /*   By: ivan-tey <ivan-tey@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2019/09/13 14:10:30 by ivan-tey       #+#    #+#                */
-/*   Updated: 2019/11/29 15:27:50 by lgutter       ########   odam.nl         */
+/*   Updated: 2019/12/04 15:35:48 by lgutter       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,8 @@ enum					e_flags
 	e_zero = 1 << 1,
 	e_space = 1 << 2,
 	e_minus = 1 << 3,
-	e_plus = 1 << 4
+	e_plus = 1 << 4,
+	e_middle = 1 << 5
 };
 
 /*
@@ -144,6 +145,7 @@ size_t					ft_correctlen(t_info *info);
 **	adding the correct width and flags
 */
 
+void					ft_write_middle_width(t_info *info, char *str);
 void					ft_write_width(t_info *info, size_t len);
 void					ft_write_flags(t_info *info);
 int						ft_write_order(t_info *info, char *str, char *order);


### PR DESCRIPTION
implemented middle width. the `^` flag will trigger the middle width, and if it can't place something exactly in the middle it will check the `-` flag like normal width.
demo code:
```
int				main(void)
{
	int		d = 42420;
	float	f = (42.0 / 5.0);
	int		width = 75;
	char	*str1 = "hello";
	char	*str2 = "This is a test of the middle width for Printf!";
	char	*str3 = "It can align this to the middle";
	char	*str4 = "of the width.";
	char	*str5 = "numbers work too:";

	ft_printf("[%^*s]\n", width, str1);
	ft_printf("[%^-*s]\n", width, str2);
	ft_printf("[%^-*s]\n", width, str3);
	ft_printf("[%^*s]\n", width, str4);
	ft_printf("[%^-*s]\n", width, str5);
	ft_printf("[%^*d]\n", width, d);
	ft_printf("[%^*x]\n", width, d);
	ft_printf("[%^*o]\n", width, d);
	ft_printf("[%^-*.10f]\n", width, f);
	return (0);
};
```
demo output:
```
[                                   hello                                   ]
[              This is a test of the middle width for Printf!               ]
[                      It can align this to the middle                      ]
[                               of the width.                               ]
[                             numbers work too:                             ]
[                                   42420                                   ]
[                                   0xa5b4                                  ]
[                                  0122664                                  ]
[                               8.3999996185                                ]
```